### PR TITLE
better yaml configuration practice

### DIFF
--- a/zeebe-cluster/templates/NOTES.txt
+++ b/zeebe-cluster/templates/NOTES.txt
@@ -8,7 +8,7 @@
 
 - Docker Image used for Broker: {{ .Values.image.repository }}:{{ .Values.image.tag }}
 - Cluster Name: {{ include "zeebe-cluster.fullname" . }}
-- ElasticSearch Enabled: {{ .Values.elasticsearch.enabled }} - URL: http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}
+- ElasticSearch Enabled: {{ .Values.elasticsearch.enabled }} - URL: http://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}
 - Kibana Enabled: {{ .Values.kibana.enabled }}
 
 The Cluster itself is not exposed as a service that means that you can use kubectl port-forward to access the Zeebe cluster from outside Kubernetes:

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -3,10 +3,11 @@ metadata:
   name: {{ include "zeebe-cluster.fullname" . }}
 apiVersion: v1
 data:
-{{- if .Values.configs."startup.sh" }}
-  startup.sh: {{ .Values.configs."startup.sh" }}
+{{- if .Values.startupScript }}
+  startup.sh: |-
+{{ .Values.startupScript | nindent 4 }}
 {{- else }}
-  startup.sh: |
+  startup.sh: |-
     #!/bin/bash -xeu
 
     configFile=/usr/local/zeebe/conf/zeebe.cfg.toml
@@ -24,10 +25,11 @@ data:
     
     exec /usr/local/zeebe/bin/broker
  {{- end }}
- {{- if .Values.configs."zeebe.cfg.toml" }}
-  zeebe.cfg.toml: {{ .Values.configs."zeebe.cfg.toml" }}
+ {{- if .Values.zeebeConfig }}
+  zeebe.cfg.toml: |-
+{{ .Values.zeebeConfig | nindent 4 }}
  {{- else }}
-  zeebe.cfg.toml: |
+  zeebe.cfg.toml: |-
     # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
     [threads]
     cpuThreadCount = 1

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -3,6 +3,9 @@ metadata:
   name: {{ include "zeebe-cluster.fullname" . }}
 apiVersion: v1
 data:
+{{- if .Values.configs."startup.sh" }}
+  startup.sh: {{ .Values.configs."startup.sh" }}
+{{- else }}
   startup.sh: |
     #!/bin/bash -xeu
 
@@ -20,38 +23,13 @@ data:
     export ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS}"
     
     exec /usr/local/zeebe/bin/broker
+ {{- end }}
+ {{- if .Values.configs."zeebe.cfg.toml" }}
+  zeebe.cfg.toml: {{ .Values.configs."zeebe.cfg.toml" }}
+ {{- else }}
   zeebe.cfg.toml: |
     # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
     [threads]
-    cpuThreadCount = {{ .Values.cpuThreadCount | quote }}
-    ioThreadCount = {{ .Values.ioThreadCount | quote }}
-    [[exporters]]
-    id = "elasticsearch"
-    className = "io.zeebe.exporter.ElasticsearchExporter"
-      [exporters.args]
-      url = "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
-
-      [exporters.args.bulk]
-      delay = 5
-      size = 1_000
-
-      #[exporters.args.authentication]
-      #username = elastic
-      #password = changeme
-
-      [exporters.args.index]
-      prefix = "zeebe-record"
-      createTemplate = true
-
-      command = false
-      event = true
-      rejection = false
-
-      deployment = true
-      incident = true
-      job = true
-      message = false
-      messageSubscription = false
-      raft = false
-      workflowInstance = true
-      workflowInstanceSubscription = false
+    cpuThreadCount = 1
+    ioThreadCount = 1
+ {{- end }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -62,18 +62,19 @@ spec:
         - name: config
           mountPath: /usr/local/bin/startup.sh
           subPath: startup.sh
+{{- if .Values.data.enabled }}
         - name: data
           mountPath: /usr/local/zeebe/data
+{{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ include "zeebe-cluster.fullname" . }}
           defaultMode: 0744
+{{- if .Values.data.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: data
     spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 5Gi
+{{ toYaml .Values.data.volumeClaimTemplate | indent 8 }}
+{{- end }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           initialDelaySeconds: 20
           periodSeconds: 5
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:
         - name: config
           mountPath: /usr/local/zeebe/conf/zeebe.cfg.toml

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -29,13 +29,13 @@ service:
     port: 26501  
   internal:
     port: 26502
-resources: 
-  requests:
-    cpu: 500m
-    memory: 1Gi
-  limits:
-    cpu: 1000m
-    memory: 2Gi
+resources:  {} # Configure resources as per your need
+  #requests:
+  #  cpu: 500m
+  #  memory: 1Gi
+  #limits:
+  #  cpu: 1000m
+  #  memory: 2Gi
 
 configs:
   startup.sh: |
@@ -58,41 +58,41 @@ configs:
   zeebe.cfg.toml: |
     # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
     [threads]
-    cpuThreadCount = {{ .Values.cpuThreadCount | quote }}
-    ioThreadCount = {{ .Values.ioThreadCount | quote }}
+    cpuThreadCount = 1
+    ioThreadCount = 1
     [[exporters]]
-    id = "elasticsearch"
-    className = "io.zeebe.exporter.ElasticsearchExporter"
-      [exporters.args]
-      url = "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
-
-      [exporters.args.bulk]
-      delay = 5
-      size = 1_000
-
-      #[exporters.args.authentication]
-      #username = elastic
-      #password = changeme
-
-      [exporters.args.index]
-      prefix = "zeebe-record"
-      createTemplate = true
-
-      command = false
-      event = true
-      rejection = false
-
-      deployment = true
-      incident = true
-      job = true
-      message = false
-      messageSubscription = false
-      raft = false
-      workflowInstance = true
-      workflowInstanceSubscription = false
+    #id = "elasticsearch"
+    #className = "io.zeebe.exporter.ElasticsearchExporter"
+    #  [exporters.args]
+    #  url = "http://elasticsearch-master:9200"
+    #
+    #  [exporters.args.bulk]
+    #  delay = 5
+    #  size = 1_000
+    #
+    #  #[exporters.args.authentication]
+    #  #username = elastic
+    #  #password = changeme
+    #
+    #  [exporters.args.index]
+    #  prefix = "zeebe-record"
+    #  createTemplate = true
+    #
+    #  command = false
+    #  event = true
+    #  rejection = false
+    #
+    #  deployment = true
+    #  incident = true
+    #  job = true
+    #  message = false
+    #  messageSubscription = false
+    #  raft = false
+    #  workflowInstance = true
+    #  workflowInstanceSubscription = false
 
 elasticsearch:
-  enabled: true
+  enabled: false
   imageTag: 6.8.1
   host: "elasticsearch-master"
   port: 9200

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -42,7 +42,7 @@ data:
   enabled: true
   volumeClaimTemplate:
     accessModes: [ "ReadWriteOnce" ]
-    storageClassName: gp2
+    storageClassName: "standard"
     resources:
       requests:
         storage: 5Gi

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -29,16 +29,17 @@ service:
     port: 26501  
   internal:
     port: 26502
-resources:  {} # Configure resources as per your need
-  #requests:
-  #  cpu: 500m
-  #  memory: 1Gi
-  #limits:
-  #  cpu: 1000m
-  #  memory: 2Gi
+
+resources:  {}
+#   requests:
+#     cpu: 500m
+#     memory: 1Gi
+#   limits:
+#     cpu: 1000m
+#     memory: 2Gi
 
 data:
-  enabled: true
+  enabled: false
   volumeClaimTemplate:
     accessModes: [ "ReadWriteOnce" ]
     storageClassName: gp2
@@ -46,59 +47,45 @@ data:
       requests:
         storage: 5Gi
         
-configs:
-  startup.sh: |
-    #!/bin/bash -xeu
+# Override the startup script if needed
+startupScript: ""
 
-    configFile=/usr/local/zeebe/conf/zeebe.cfg.toml
-    export ZEEBE_HOST=$(hostname -f)
-    export ZEEBE_NODE_ID="${HOSTNAME##*-}"
-    
-    # We need to specify all brokers as contact points for partition healing to work correctly
-    # https://github.com/zeebe-io/zeebe/issues/2684
-    ZEEBE_CONTACT_POINTS=${HOSTNAME::-1}0.$(hostname -d):26502
-    for (( i=1; i<$ZEEBE_CLUSTER_SIZE; i++ ))
-    do
-        ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS},${HOSTNAME::-1}$i.$(hostname -d):26502"
-    done
-    export ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS}"
-    
-    exec /usr/local/zeebe/bin/broker
-  zeebe.cfg.toml: |
-    # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
-    [threads]
-    cpuThreadCount = 1
-    ioThreadCount = 1
-    [[exporters]]
-    #id = "elasticsearch"
-    #className = "io.zeebe.exporter.ElasticsearchExporter"
-    #  [exporters.args]
-    #  url = "http://elasticsearch-master:9200"
-    #
-    #  [exporters.args.bulk]
-    #  delay = 5
-    #  size = 1_000
-    #
-    #  #[exporters.args.authentication]
-    #  #username = elastic
-    #  #password = changeme
-    #
-    #  [exporters.args.index]
-    #  prefix = "zeebe-record"
-    #  createTemplate = true
-    #
-    #  command = false
-    #  event = true
-    #  rejection = false
-    #
-    #  deployment = true
-    #  incident = true
-    #  job = true
-    #  message = false
-    #  messageSubscription = false
-    #  raft = false
-    #  workflowInstance = true
-    #  workflowInstanceSubscription = false
+# zeebe.conf.toml
+zeebeConfig: |-
+  # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
+  [threads]
+  cpuThreadCount = 1
+  ioThreadCount = 1
+  [[exporters]]
+  #id = "elasticsearch"
+  #className = "io.zeebe.exporter.ElasticsearchExporter"
+  #  [exporters.args]
+  #  url = "http://elasticsearch-master:9200"
+  #
+  #  [exporters.args.bulk]
+  #  delay = 5
+  #  size = 1_000
+  #
+  #  #[exporters.args.authentication]
+  #  #username = elastic
+  #  #password = changeme
+  #
+  #  [exporters.args.index]
+  #  prefix = "zeebe-record"
+  #  createTemplate = true
+  #
+  #  command = false
+  #  event = true
+  #  rejection = false
+  #
+  #  deployment = true
+  #  incident = true
+  #  job = true
+  #  message = false
+  #  messageSubscription = false
+  #  raft = false
+  #  workflowInstance = true
+  #  workflowInstanceSubscription = false
 
 elasticsearch:
   enabled: false

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -5,15 +5,6 @@
 partitionCount: "3"
 clusterSize: "3"
 replicationFactor: "3"
-cpuThreadCount: "2"
-ioThreadCount: "2"
-
-elasticsearch:
-  enabled: true
-  imageTag: 6.8.1
-kibana:
-  enabled: false
-  imageTag: 6.8.1
 
 JavaOpts: |
   -XX:+UseParallelGC 
@@ -45,7 +36,67 @@ resources:
   limits:
     cpu: 1000m
     memory: 2Gi
-global: 
-  elasticsearch:
-    host: "elasticsearch-master"
-    port: 9200 
+
+configs:
+  startup.sh: |
+    #!/bin/bash -xeu
+
+    configFile=/usr/local/zeebe/conf/zeebe.cfg.toml
+    export ZEEBE_HOST=$(hostname -f)
+    export ZEEBE_NODE_ID="${HOSTNAME##*-}"
+    
+    # We need to specify all brokers as contact points for partition healing to work correctly
+    # https://github.com/zeebe-io/zeebe/issues/2684
+    ZEEBE_CONTACT_POINTS=${HOSTNAME::-1}0.$(hostname -d):26502
+    for (( i=1; i<$ZEEBE_CLUSTER_SIZE; i++ ))
+    do
+        ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS},${HOSTNAME::-1}$i.$(hostname -d):26502"
+    done
+    export ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS}"
+    
+    exec /usr/local/zeebe/bin/broker
+  zeebe.cfg.toml: |
+    # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
+    [threads]
+    cpuThreadCount = {{ .Values.cpuThreadCount | quote }}
+    ioThreadCount = {{ .Values.ioThreadCount | quote }}
+    [[exporters]]
+    id = "elasticsearch"
+    className = "io.zeebe.exporter.ElasticsearchExporter"
+      [exporters.args]
+      url = "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
+
+      [exporters.args.bulk]
+      delay = 5
+      size = 1_000
+
+      #[exporters.args.authentication]
+      #username = elastic
+      #password = changeme
+
+      [exporters.args.index]
+      prefix = "zeebe-record"
+      createTemplate = true
+
+      command = false
+      event = true
+      rejection = false
+
+      deployment = true
+      incident = true
+      job = true
+      message = false
+      messageSubscription = false
+      raft = false
+      workflowInstance = true
+      workflowInstanceSubscription = false
+
+elasticsearch:
+  enabled: true
+  imageTag: 6.8.1
+  host: "elasticsearch-master"
+  port: 9200
+  
+kibana:
+  enabled: false
+  imageTag: 6.8.1

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -39,7 +39,7 @@ resources:  {}
 #     memory: 2Gi
 
 data:
-  enabled: false
+  enabled: true
   volumeClaimTemplate:
     accessModes: [ "ReadWriteOnce" ]
     storageClassName: gp2

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -37,6 +37,15 @@ resources:  {} # Configure resources as per your need
   #  cpu: 1000m
   #  memory: 2Gi
 
+data:
+  enabled: true
+  volumeClaimTemplate:
+    accessModes: [ "ReadWriteOnce" ]
+    storageClassName: gp2
+    resources:
+      requests:
+        storage: 5Gi
+        
 configs:
   startup.sh: |
     #!/bin/bash -xeu


### PR DESCRIPTION
I have faced problem to configure the zeebe.cfg.toml and other attributes in the existing zeebe-cluster helm chart. This PR will fix the following issues. Feel free to comment.

1. Ability to modify the zeebe.config.toml as per the user, in the current system, the values are configured as part of the template and which is not leveraging the ability to configure apart from the config values added in the yaml, which thread counts for only. This PR moved the config values as a separate field in values.yaml and hence can be modified as required.
2. Since the config.toml is moved fully read from the values.yaml, further configurations like threadCount all can be removed and user can configure them in the config file.
3. There was no way to configure the volume claim template apart from the 5gb as per the current configuration, this PR user can define whatever the volume type they want to use.
4. In the current model by default exporter for elasticsearch is configured, and user doesn't have an option to avoid setting up elastic search. Even the elasticsearch.enabled wil not remove the elastic exporter config, this PR will comment the default exporter configs, make the elastic and kibana by default disabled.
5. No configurations for resource, sometime the configured amount will not be sufficient to boot up, Better user to configures it.