### PR TITLE
Update elasticsearch/kibana image tags

### DIFF
--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -35,11 +35,11 @@ gateway:
 
 elasticsearch:
   enabled: true
-  imageTag: 6.8.5
+  imageTag: 7.10.1
 
 kibana:
   enabled: false
-  imageTag: 6.8.5
+  imageTag: 7.10.1
 
 prometheus:
   enabled: false

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -35,11 +35,11 @@ gateway:
 
 elasticsearch:
   enabled: true
-  imageTag: 7.10.1
+  imageTag: 7.12.1
 
 kibana:
   enabled: false
-  imageTag: 7.10.1
+  imageTag: 7.12.1
 
 prometheus:
   enabled: false


### PR DESCRIPTION
This PR updates the elasticsearch and kibana image tags from 6.8.5 to 7.10.1. 

Ref: #114 #115 




