### PR TITLE
Adding value to parameterize the type of service to be created for the Cluster Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ This functionality is in beta and is subject to change. The design and code is l
 | `gateway.podDisruptionBudget.enabled`         | Create a PodDisruptionBudget for the gateway pods | `false`
 | `gateway.podDisruptionBudget.minAvailable`         | minimum number of available gateway pods for PodDisruptionBudget | `1`
 | `gateway.podDisruptionBudget.maxUnavailable`       | maximum number of unavailable gateway pods for PodDisruptionBudget |
+| `serviceType`         | The type of cluster service | `ClusterIP`
+| `serviceGatewayType`         | The type of cluster gateway service | `ClusterIP`
 | `serviceHttpPort`         | The http port used by the brokers and the gateway| `9600`
 | `serviceGatewayPort`         | The gateway port used by the gateway | `26500`
 | `serviceInternalPort`         | The internal port used by the brokers and the gateway | `26502`

--- a/charts/zeebe-cluster-helm/templates/gateway-service.yaml
+++ b/charts/zeebe-cluster-helm/templates/gateway-service.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- toYaml  .Values.annotations | nindent 4 }}
 spec:
+  type: {{ .Values.serviceGatewayType }}
   selector:
     {{- include "zeebe-cluster.labels.gateway" . | nindent 6 }}
   ports:

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -56,6 +56,7 @@ JavaOpts: >-
 labels:
   app: zeebe    
 serviceType: ClusterIP
+serviceGatewayType: ClusterIP
 serviceHttpPort: 9600
 serviceGatewayPort: 26500    
 serviceCommandPort: 26501     


### PR DESCRIPTION
Adding value to parameterize the type of service to be created for the Cluster Gateway.

This will allow us to use the `LoadBalancer` type in the Gateway service to execute `zbctl` commands from outside the kubernetes cluster running on some cloud provider.